### PR TITLE
Simplify Resource Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 * Adds GitHub actions (#2) ([7898b7a](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/7898b7a)), closes [#2](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/2)
 * updates docs format (#3) ([2bcebe7](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/2bcebe7)), closes [#3](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/3)
 
-
-
 ## 0.2.0 (2020-02-10)
 
 * adds base files ([32eeffc](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/32eeffc))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-##  (2020-02-24)
+#  (2020-02-24)
 
 * Adds GitHub actions (#2) ([7898b7a](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/7898b7a)), closes [#2](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/2)
 * updates docs format (#3) ([2bcebe7](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/2bcebe7)), closes [#3](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,3 @@
 
 * adds base files ([32eeffc](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/32eeffc))
 * Create resources (#1) ([9389617](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/9389617)), closes [#1](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/1)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#  (2020-02-24)
+# (2020-02-24)
 
 * Adds GitHub actions (#2) ([7898b7a](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/7898b7a)), closes [#2](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/2)
 * updates docs format (#3) ([2bcebe7](https://github.com/operatehappy/terraform-aws-acm-certificate/commit/2bcebe7)), closes [#3](https://github.com/operatehappy/terraform-aws-acm-certificate/issues/3)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module depends on a correctly configured [AWS Provider](https://www.terrafo
 Add the module to your Terraform resources like so:
 
 ```hcl
-module "acm-certificate" {
+module "acm_certificate" {
   source  = "operatehappy/acm-certificate/aws"
   version = "1.0.0"
 
@@ -44,12 +44,12 @@ module "acm-certificate" {
   domain_name            = var.domain_name
   alternate_domain_names = var.alternate_domain_names
 
-  use_default_tags                    = true
-  tags                                = {
+  use_default_tags = true
+  tags = {
     website = "https://example.com/"
   }
 
-  route53_zone_id                     = "Z3P5QSUBK4POTI"
+  route53_zone_id = "Z3P5QSUBK4POTI"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Overview
 
-![Terraform Module: AWS ACM Certificate](./overview.png "Terraform Module: AWS ACM Certificate")
+![Terraform Module: AWS ACM Certificate](https://github.com/operatehappy/terraform-aws-acm-certificate/blob/master/overview.png "Terraform Module: AWS ACM Certificate")
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Additional usage examples are available in the `examples` directory via [GitHub]
 
 ## Author Information
 
-This module is maintained by the contributors listed on [GitHub](https://github.com/operatehappy/terraform-aws-acm-certificate/graphs/contributors)
+This module is maintained by the contributors listed on [GitHub](https://github.com/operatehappy/terraform-aws-acm-certificate/graphs/contributors).
 
 Development of this module was sponsored by [Operate Happy](https://github.com/operatehappy).
 
@@ -86,7 +86,7 @@ Development of this module was sponsored by [Operate Happy](https://github.com/o
 
 Licensed under the Apache License, Version 2.0 (the "License").
 
-You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
+You may obtain a copy of the License at [apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an _"AS IS"_ basis, without WARRANTIES or conditions of any kind, either express or implied.
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,4 @@
-resource "aws_acm_certificate" "certificate" {
+resource "aws_acm_certificate" "this" {
   domain_name               = var.domain_name
   subject_alternative_names = var.alternate_domain_names
   validation_method         = "DNS"
@@ -10,12 +10,12 @@ resource "aws_acm_certificate" "certificate" {
   }
 }
 
-resource "aws_route53_record" "validation" {
+resource "aws_route53_record" "this" {
   count = length([var.domain_name, var.alternate_domain_names])
 
   zone_id = var.route53_zone_id
-  name    = aws_acm_certificate.certificate.domain_validation_options[count.index].resource_record_name
-  type    = aws_acm_certificate.certificate.domain_validation_options[count.index].resource_record_type
+  name    = aws_acm_certificate.this.domain_validation_options[count.index].resource_record_name
+  type    = aws_acm_certificate.this.domain_validation_options[count.index].resource_record_type
   ttl     = 60
 
   records = [
@@ -25,15 +25,15 @@ resource "aws_route53_record" "validation" {
   allow_overwrite = true // NOTE: this is required for Certificate Validation
 
   depends_on = [
-    aws_acm_certificate.certificate
+    aws_acm_certificate.this
   ]
 }
 
-resource "aws_acm_certificate_validation" "validation" {
-  count = length(aws_route53_record.validation)
+resource "aws_acm_certificate_validation" "this" {
+  count = length(aws_route53_record.this)
 
-  certificate_arn         = aws_acm_certificate.certificate.arn
-  validation_record_fqdns = aws_route53_record.validation.*.fqdn
+  certificate_arn         = aws_acm_certificate.this.arn
+  validation_record_fqdns = aws_route53_record.this.*.fqdn
 
   timeouts {
     create = "60m"

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_route53_record" "this" {
   ttl     = 60
 
   records = [
-    aws_acm_certificate.certificate.domain_validation_options[count.index].resource_record_value
+    aws_acm_certificate.this.domain_validation_options[count.index].resource_record_value
   ]
 
   allow_overwrite = true // NOTE: this is required for Certificate Validation

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,23 @@
 output "id" {
-  value       = aws_acm_certificate.certificate.id
+  value       = aws_acm_certificate.this.id
   description = "ID of the Certificate"
   depends_on = [
-    aws_acm_certificate.certificate
+    aws_acm_certificate.this
   ]
 }
 
 output "arn" {
-  value       = aws_acm_certificate.certificate.arn
+  value       = aws_acm_certificate.this.arn
   description = "ARN of the Certificate"
   depends_on = [
-    aws_acm_certificate.certificate
+    aws_acm_certificate.this
   ]
 }
 
 output "domain_name" {
-  value       = aws_acm_certificate.certificate.domain_name
+  value       = aws_acm_certificate.this.domain_name
   description = "Domain name for which the certificate is issued"
   depends_on = [
-    aws_acm_certificate.certificate
+    aws_acm_certificate.this
   ]
 }


### PR DESCRIPTION
This switches resource names from service-specific names to `this` in order to make maintenance of modules easier.

Has no impact on outputs.