### PR TITLE
Use `concat` before using `length`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Overview
 
-![Terraform Module: AWS ACM Certificate](https://github.com/operatehappy/terraform-aws-acm-certificate/blob/master/overview.png "Terraform Module: AWS ACM Certificate")
+![Terraform Module: AWS ACM Certificate](https://raw.githubusercontent.com/operatehappy/terraform-aws-acm-certificate/master/overview.png "Terraform Module: AWS ACM Certificate")
 
 ## Requirements
 

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_acm_certificate" "this" {
 }
 
 resource "aws_route53_record" "this" {
-  count = length([var.domain_name, var.alternate_domain_names])
+  count = length(concat([var.domain_name], var.alternate_domain_names))
 
   zone_id = var.route53_zone_id
   name    = aws_acm_certificate.this.domain_validation_options[count.index].resource_record_name


### PR DESCRIPTION
This PR uses `concat` for `aws_route53_record.this` before using the `length` function.

Additionally, I've also switched the link to the overview to use `raw.githubusercontent.com` so it renders better in off-GitHub systems.